### PR TITLE
use opt_fields to avoid one /task/ api request per task

### DIFF
--- a/AsanaApi.php
+++ b/AsanaApi.php
@@ -57,31 +57,29 @@ class AsanaApi {
     }
     
     public function getTasks($workspaceId){
-        return $this->apiRequest($this->workspaceUri.'/'.$workspaceId.'/tasks?assignee=me');
+        return $this->apiRequest($this->workspaceUri.'/'.$workspaceId.'/tasks?assignee=me&opt_fields=name,completed,projects,projects.name,parent,parent.name');
     }
     
-    public function getOneTask($taskId){
-        $resultJson = json_decode($this->apiRequest($this->taskUri.'/'.$taskId));
-        
+    public function getTaskState($data){
         $castIntoArray = array();
 
-        if(array_key_exists(0, $resultJson->data->projects)) {
-            $castIntoArray = (array)$resultJson->data->projects[0];
+        if(array_key_exists(0, $data->projects)) {
+            $castIntoArray = (array)$data->projects[0];
         }
-        elseif(is_object($resultJson->data->parent)){
+        elseif(is_object($data->parent)){
             $castIntoArray = array(
-                                'id' => $resultJson->data->parent->id,
-                                'name' => 'PARENT TASK: '.$resultJson->data->parent->name
+                                'id' => $data->parent->id,
+                                'name' => 'PARENT TASK: '.$data->parent->name
                              );
         }
         else{
             $castIntoArray = array(
-                                'id' => $resultJson->data->id,
+                                'id' => $data->id,
                                 'name' => 'NO PROJECT'
                              );
         }
 
-        $array = array ( 'completed' => $resultJson->data->completed,
+        $array = array ( 'completed' => $data->completed,
                          'projects' => $castIntoArray
                        );
 

--- a/AsanaApi.php
+++ b/AsanaApi.php
@@ -82,7 +82,6 @@ class AsanaApi {
         }
 
         $array = array ( 'completed' => $resultJson->data->completed,
-                         'assignee' => $resultJson->data->assignee->id,
                          'projects' => $castIntoArray
                        );
 

--- a/request.php
+++ b/request.php
@@ -50,7 +50,7 @@ if($asana->getResponseCode() == '200' && $result != '' ){
         foreach($result->data as $task){
              
              $value = $asana->getEstimatedAndWorkedTime($task->name);
-             $taskState = $asana->getOneTask($task->id);
+             $taskState = $asana->getTaskState($task);
 
              $taskName = $value['taskName'];
              $estimatedHours = (!empty($value['estimatedHours'])) ? $value['estimatedHours'].'h' : '0h';

--- a/request.php
+++ b/request.php
@@ -20,7 +20,6 @@ $updateId = !empty($_GET['updateId']) ? $_GET['updateId'] : '';
 // initalize
 $asana = new AsanaApi($apiKey); 
 $result = $asana->getWorkspaces();
-$userId = $asana->getUserId();
 
 // check if everything works fine
 if($asana->getResponseCode() == '200' && $result != '' ){
@@ -70,8 +69,8 @@ if($asana->getResponseCode() == '200' && $result != '' ){
              
              $progressState = ($progressBarPercent < 80) ? 'progress-success' : (($progressBarPercent < 100 ) ? 'progress-warning' : 'progress-danger');
              
-             // task must be active and your own
-             if($taskState['completed'] || $taskState['assignee'] != $userId || $taskName == '') {
+             // task must be active
+             if($taskState['completed'] || $taskName == '') {
                 continue;
              } else {
                 echo '<tr>'


### PR DESCRIPTION
Fetching tasks was taking forever. I thought my nginx/fastcgi was at fault (buffering etc). After digging into the source however, I learned I was barking down the wrong tree; we were retrieving task details with a API request on a per-task basis! Since I'm quite far from Asana's servers, plus I have a biggish workspace, so I was hit pretty hard.

Some googling led me to the `opt_fields` parameter [1], allowing us to re-use the task listing API request to obtain details on all tasks.

[1] http://stackoverflow.com/a/11660287

Also skips checking of assignee (see message of 118d398 for reasoning).
